### PR TITLE
paragraphs should be separated by a blank line

### DIFF
--- a/lib/html2markdown/converter.rb
+++ b/lib/html2markdown/converter.rb
@@ -46,6 +46,8 @@ module HTML2Markdown
         contents.split('\n').each do |part|
           result << ">#{contents}\n"
         end
+      when 'p'
+        result << "\n#{contents}\n"
       when 'strong'
         result << "**#{contents}**\n"
       when 'h1'

--- a/spec/cases/html_page_spec.rb
+++ b/spec/cases/html_page_spec.rb
@@ -92,4 +92,7 @@ NEXT！<br>
     p.markdown!.should be_include('strong text')
   end
 
+  it 'separates paragraphs like you do' do
+    HTMLPage.new(contents: '<p>Goodbye</p><p>Hello</p>').markdown.should == "Goodbye\n\nHello"
+  end
 end


### PR DESCRIPTION
This minor change resolves an issue I faced:

    <p>Hello</p><p>Goodbye</p>

previously resulted in

    HelloGoodbye

but now results in

    Hello

    Goodbye

Thanks for the time you put into this gem... exactly what I needed. Except for the bug. :)