### PR TITLE
Address "literal string will be frozen in the future" warnings

### DIFF
--- a/lib/html2markdown/converter.rb
+++ b/lib/html2markdown/converter.rb
@@ -27,7 +27,7 @@ module HTML2Markdown
 
     # wrap node with markdown
     def wrap_node(node,contents=nil)
-      result = ''
+      result = ''.dup
       contents.strip! unless contents==nil
       # check if there is a custom parse exist
       if respond_to? "parse_#{node.name}"

--- a/lib/html2markdown/html_page.rb
+++ b/lib/html2markdown/html_page.rb
@@ -9,7 +9,7 @@ class HTMLPage
     @host = options[:host]
     @url = options[:url]
     if (@contents = options[:contents]) == nil
-      doc = Nokogiri::HTML(open(@url))
+      doc = Nokogiri::HTML(URI.open(@url))
       @contents = doc.at_css('body').send(:inner_html) || doc.inner_html
     end
     @content_extrator = content_extrator


### PR DESCRIPTION
Should resolve #14.

* `dup` the initial `result` to avoid freezing and failing down the codepaths that modify it.
* Fix opening the URL by swapping `open` with `URI.open` - Kernel monkey-patch has been removed from `open-uri` long time ago. I did not test it locally with Rubies that predate 2.6.6.